### PR TITLE
Show info if tag name is empty

### DIFF
--- a/src/Athena.UI/Content/ViewModel/Tags/Entity/TagViewModel.cs
+++ b/src/Athena.UI/Content/ViewModel/Tags/Entity/TagViewModel.cs
@@ -32,7 +32,6 @@ namespace Athena.UI
             }
         }
 
-
         public string Name
         {
             get => _tag.Name;
@@ -74,6 +73,5 @@ namespace Athena.UI
         {
             return tagVm._tag;
         }
-
     }
 }

--- a/src/Athena.UI/Content/ViewModel/Tags/TagsOverviewViewModel.cs
+++ b/src/Athena.UI/Content/ViewModel/Tags/TagsOverviewViewModel.cs
@@ -137,10 +137,18 @@ namespace Athena.UI
         }
 
         [RelayCommand]
-        public void SaveSelectedTag()
+        public async Task SaveSelectedTag()
         {
             if (SelectedTag == null)
                 return;
+
+            if (string.IsNullOrEmpty(SelectedTagName))
+            {
+                await Toast.Make(Localization.TagNameCannotBeEmpty, ToastDuration.Long).Show();
+                SelectedTag = null;
+                IsEditPopupOpen = false;
+                return;
+            }
 
             bool isNew = SelectedTag.Id == IntegerEntityKey.TemporaryId;
 

--- a/src/Athena.UI/Resources/Localization/Localization.Designer.cs
+++ b/src/Athena.UI/Resources/Localization/Localization.Designer.cs
@@ -1828,6 +1828,15 @@ namespace Athena.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The name cannot be empty.
+        /// </summary>
+        public static string TagNameCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("TagNameCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Choose a new name for {0}.
         /// </summary>
         public static string TagNewName {

--- a/src/Athena.UI/Resources/Localization/Localization.de-DE.resx
+++ b/src/Athena.UI/Resources/Localization/Localization.de-DE.resx
@@ -784,4 +784,7 @@ Please note that the key is not your password.</comment>
   <data name="PasswordNewHint" xml:space="preserve">
     <value>Neues Password eingeben</value>
   </data>
+  <data name="TagNameCannotBeEmpty" xml:space="preserve">
+    <value>Der Name darf nicht leer sein</value>
+  </data>
 </root>

--- a/src/Athena.UI/Resources/Localization/Localization.resx
+++ b/src/Athena.UI/Resources/Localization/Localization.resx
@@ -772,4 +772,7 @@ Please note that the key is not your password.</value>
   <data name="PasswordNewHint" xml:space="preserve">
     <value>Enter your new password</value>
   </data>
+  <data name="TagNameCannotBeEmpty" xml:space="preserve">
+    <value>The name cannot be empty</value>
+  </data>
 </root>


### PR DESCRIPTION
Cannot be done by disabling the button, error info is shown instead.
Fixes #61.